### PR TITLE
Add support for user domains (bug 1471882)

### DIFF
--- a/docs/Agent.md
+++ b/docs/Agent.md
@@ -87,6 +87,8 @@ All parameters require a '--' before the parameter such as '--verbose'. Run `mon
 | ----------- | ------------ | ----------- |
 | username | This is a required parameter that specifies the username needed to login to Keystone to get a token | myuser |
 | password | This is a required parameter that specifies the password needed to login to Keystone to get a token | mypassword |
+| user_domain_id | User domain id for username scoping | dcff2e7ede243eb7b3c2c1d57cfc46d1 |
+| user_domain_name | User domain name for username scoping | MyDomain |
 | project_name | Specifies the name of the Keystone project name to store the metrics under, defaults to users default project. | myproject |
 | project_domain_id | Project domain id for keystone authentication | |
 | project_domain_name | Project domain name for keystone authentication | |

--- a/monasca_agent/common/keystone.py
+++ b/monasca_agent/common/keystone.py
@@ -42,7 +42,7 @@ class Keystone(object):
 	elif user_domain_name:
             kc_args.update({'user_domain_name': user_domain_name})
        
-	 if insecure:
+        if insecure:
             kc_args.update({'insecure': insecure})
         else:
             if cacert:

--- a/monasca_agent/common/keystone.py
+++ b/monasca_agent/common/keystone.py
@@ -30,14 +30,19 @@ class Keystone(object):
         cacert = self.config.get('ca_file', None)
         project_id = self.config.get('project_id', None)
         project_name = self.config.get('project_name', None)
-        project_domain_name = self.config.get('domain_name', None)
-        project_domain_id = self.config.get('domain_id', None)
+        project_domain_name = self.config.get('project_domain_name', None)
+        project_domain_id = self.config.get('project_domain_id', None)
 
         kc_args = {'auth_url': auth_url,
                    'username': username,
                    'password': password}
 
-        if insecure:
+	if domain_id:
+            kc_args.update({'user_domain_id': domain_id})
+	elif domain_name:
+            kc_args.update({'user_domain_name': domain_name})
+       
+	 if insecure:
             kc_args.update({'insecure': insecure})
         else:
             if cacert:
@@ -50,13 +55,6 @@ class Keystone(object):
                 kc_args.update({'domain_name': project_domain_name})
             if project_domain_id:
                 kc_args.update({'domain_id': project_domain_id})
-	elif domain_id:
-                kc_args.update({'user_domain_id': domain_id})
-	elif domain_name:
-                kc_args.update({'user_domain_name': domain_name})
-
-        # TO BE REMOVED BY JOACHIM
-        log.info("Creating the Keystone Client for {0}".format(repr(kc_args))) 
 
         return ksclient.KSClient(**kc_args)
 

--- a/monasca_agent/common/keystone.py
+++ b/monasca_agent/common/keystone.py
@@ -24,12 +24,14 @@ class Keystone(object):
         auth_url = self.config.get('keystone_url', None)
         username = self.config.get('username', None)
         password = self.config.get('password', None)
+	domain_id = self.config.get('domain_id', None)
+	domain_name = self.config.get('domain_name', None)
         insecure = self.config.get('insecure', False)
         cacert = self.config.get('ca_file', None)
         project_id = self.config.get('project_id', None)
         project_name = self.config.get('project_name', None)
-        project_domain_name = self.config.get('project_domain_name', None)
-        project_domain_id = self.config.get('project_domain_id', None)
+        project_domain_name = self.config.get('domain_name', None)
+        project_domain_id = self.config.get('domain_id', None)
 
         kc_args = {'auth_url': auth_url,
                    'username': username,
@@ -48,6 +50,13 @@ class Keystone(object):
                 kc_args.update({'domain_name': project_domain_name})
             if project_domain_id:
                 kc_args.update({'domain_id': project_domain_id})
+	elif domain_id:
+                kc_args.update({'user_domain_id': domain_id})
+	elif domain_name:
+                kc_args.update({'user_domain_name': domain_name})
+
+        # TO BE REMOVED BY JOACHIM
+        log.info("Creating the Keystone Client for {0}".format(repr(kc_args))) 
 
         return ksclient.KSClient(**kc_args)
 

--- a/monasca_agent/common/keystone.py
+++ b/monasca_agent/common/keystone.py
@@ -24,8 +24,8 @@ class Keystone(object):
         auth_url = self.config.get('keystone_url', None)
         username = self.config.get('username', None)
         password = self.config.get('password', None)
-	domain_id = self.config.get('domain_id', None)
-	domain_name = self.config.get('domain_name', None)
+	user_domain_id = self.config.get('user_domain_id', None)
+	user_domain_name = self.config.get('user_domain_name', None)
         insecure = self.config.get('insecure', False)
         cacert = self.config.get('ca_file', None)
         project_id = self.config.get('project_id', None)
@@ -37,10 +37,10 @@ class Keystone(object):
                    'username': username,
                    'password': password}
 
-	if domain_id:
-            kc_args.update({'user_domain_id': domain_id})
-	elif domain_name:
-            kc_args.update({'user_domain_name': domain_name})
+	if user_domain_id:
+            kc_args.update({'user_domain_id': user_domain_id})
+	elif user_domain_name:
+            kc_args.update({'user_domain_name': user_domain_name})
        
 	 if insecure:
             kc_args.update({'insecure': insecure})

--- a/monasca_setup/main.py
+++ b/monasca_setup/main.py
@@ -56,6 +56,8 @@ def main(argv=None):
         '-u', '--username', help="Username used for keystone authentication. Required for basic configuration.")
     parser.add_argument(
         '-p', '--password', help="Password used for keystone authentication. Required for basic configuration.")
+    parser.add_argument('--user_domain_id', help="User domain id for keystone authentication", default='')
+    parser.add_argument('--user_domain_name', help="User domain name for keystone authentication", default='')
     parser.add_argument('--keystone_url', help="Keystone url. Required for basic configuration.")
     parser.add_argument('--project_name', help="Project name for keystone authentication", default='')
     parser.add_argument('--project_domain_id', help="Project domain id for keystone authentication", default='')


### PR DESCRIPTION
Added configuration parameters for specifying the domain of a user and ensured that these parameters reach the Keystone API. 

Fix for https://bugs.launchpad.net/monasca/+bug/1471882